### PR TITLE
Added A Flow to Use Standard or Custom Rationale

### DIFF
--- a/app/src/main/java/com/vmadalin/easypermissions/sample/MainActivity.kt
+++ b/app/src/main/java/com/vmadalin/easypermissions/sample/MainActivity.kt
@@ -22,11 +22,13 @@ import android.util.Log
 import android.widget.Toast
 import android.widget.Toast.LENGTH_LONG
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.activity_main.*
+import com.vmadalin.easypermissions.EasyPermissions
 import com.vmadalin.easypermissions.annotations.AfterPermissionGranted
 import com.vmadalin.easypermissions.dialogs.DEFAULT_SETTINGS_REQ_CODE
 import com.vmadalin.easypermissions.dialogs.SettingsDialog
-import com.vmadalin.easypermissions.EasyPermissions
+import com.vmadalin.easypermissions.helpers.base.PermissionsHelper
+import com.vmadalin.easypermissions.models.PermissionRequest
+import kotlinx.android.synthetic.main.activity_main.*
 
 private const val TAG = "MainActivity"
 private const val REQUEST_CODE_CAMERA_PERMISSION = 123
@@ -132,8 +134,11 @@ class MainActivity : AppCompatActivity(),
             // Ask for one permission
             EasyPermissions.requestPermissions(
                 this,
-                getString(R.string.permission_camera_rationale_message),
                 REQUEST_CODE_CAMERA_PERMISSION,
+                EasyPermissions.RationaleType.CustomRationale { request ->
+                    //TODO: Show customize rational (Not required)
+                    showTODORationalCustomDialog(request)
+                },
                 CAMERA
             )
         }
@@ -148,8 +153,8 @@ class MainActivity : AppCompatActivity(),
             // Ask for one permission
             EasyPermissions.requestPermissions(
                 this,
-                getString(R.string.permission_storage_rationale_message),
                 REQUEST_CODE_STORAGE_PERMISSION,
+                EasyPermissions.RationaleType.StandardRationale("TODO: Message"),
                 WRITE_EXTERNAL_STORAGE
             )
         }
@@ -164,8 +169,11 @@ class MainActivity : AppCompatActivity(),
             // Ask for both permissions
             EasyPermissions.requestPermissions(
                 this,
-                getString(R.string.permission_location_and_contacts_rationale_message),
                 REQUEST_CODE_LOCATION_AND_CONTACTS_PERMISSION,
+                EasyPermissions.RationaleType.CustomRationale { request ->
+                    //TODO: Show customize rational (Not required)
+                    showTODORationalCustomDialog(request)
+                },
                 ACCESS_FINE_LOCATION, READ_CONTACTS
             )
         }
@@ -185,5 +193,24 @@ class MainActivity : AppCompatActivity(),
 
     private fun hasStoragePermission(): Boolean {
         return EasyPermissions.hasPermissions(this, WRITE_EXTERNAL_STORAGE)
+    }
+
+    private fun showTODORationalCustomDialog(request: PermissionRequest) {
+        android.app.AlertDialog.Builder(this)
+            .setCancelable(false)
+            .setMessage("TODO: custom Rational Message")
+            .setPositiveButton("Yes") { view, _ ->
+                PermissionsHelper
+                    .newInstance(this)
+                    .directRequestPermissions(
+                        request.code,
+                        request.perms
+                    )
+                view.dismiss()
+            }
+            .setNegativeButton("No") { view, _ ->
+                view.dismiss()
+            }
+            .show()
     }
 }

--- a/app/src/main/java/com/vmadalin/easypermissions/sample/MainFragment.kt
+++ b/app/src/main/java/com/vmadalin/easypermissions/sample/MainFragment.kt
@@ -26,6 +26,8 @@ import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_main.*
 import com.vmadalin.easypermissions.annotations.AfterPermissionGranted
 import com.vmadalin.easypermissions.EasyPermissions
+import com.vmadalin.easypermissions.helpers.base.PermissionsHelper
+import com.vmadalin.easypermissions.models.PermissionRequest
 
 private const val TAG = "MainFragment"
 private const val REQUEST_CODE_SMS_PERMISSION = 126
@@ -89,8 +91,8 @@ class MainFragment : Fragment(), EasyPermissions.PermissionCallbacks {
             // Request one permission
             EasyPermissions.requestPermissions(
                 this,
-                getString(R.string.permission_sms_rationale_message),
                 REQUEST_CODE_SMS_PERMISSION,
+                EasyPermissions.RationaleType.StandardRationale("TODO: Message"),
                 Manifest.permission.READ_SMS
             )
         }

--- a/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/EasyPermissions.kt
+++ b/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/EasyPermissions.kt
@@ -99,8 +99,9 @@ object EasyPermissions {
     @JvmStatic
     fun requestPermissions(
         host: Activity,
-        rationale: String,
         requestCode: Int,
+        //Changed rationale param by Rationale Type which can allows Standard or Custom Rationales
+        rationale: RationaleType,
         @Size(min = 1) vararg perms: String
     ) {
         val request = PermissionRequest.Builder(host)
@@ -110,7 +111,6 @@ object EasyPermissions {
             .build()
         requestPermissions(host, request)
     }
-
     /**
      * Request permissions from a Support Fragment with standard OK/Cancel buttons.
      *
@@ -119,8 +119,9 @@ object EasyPermissions {
     @JvmStatic
     fun requestPermissions(
         host: Fragment,
-        rationale: String,
         requestCode: Int,
+        //Changed rationale param by Rationale Type which can allows Standard or Custom Rationales
+        rationale: RationaleType,
         @Size(min = 1) vararg perms: String
     ) {
         val request = PermissionRequest.Builder(host.context)
@@ -324,5 +325,15 @@ object EasyPermissions {
     ) {
         val grantResults = IntArray(perms.size) { PackageManager.PERMISSION_GRANTED }
         onRequestPermissionsResult(requestCode, perms, grantResults, receiver)
+    }
+
+    /**
+     * Class which define type of Rationale. Can be used a Standard Rationale and send a string which is provided by EasyPermission library
+     * or Custom Rationale where you can send your own Rationale.
+     *
+     */
+    sealed class RationaleType {
+        class StandardRationale(val rationale: String) : RationaleType()
+        class CustomRationale(val rationale: (PermissionRequest) -> Unit) : RationaleType()
     }
 }

--- a/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/dialogs/RationaleDialog.kt
+++ b/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/dialogs/RationaleDialog.kt
@@ -33,7 +33,8 @@ import com.vmadalin.easypermissions.models.PermissionRequest
  */
 class RationaleDialog(
     private val context: Context,
-    private val model: PermissionRequest
+    private val model: PermissionRequest,
+    private val rationale: String
 ) : DialogInterface.OnClickListener {
 
     private val permissionCallbacks: EasyPermissions.PermissionCallbacks?
@@ -47,7 +48,7 @@ class RationaleDialog(
     fun showCompatDialog() {
         AlertDialog.Builder(context, model.theme)
             .setCancelable(false)
-            .setMessage(model.rationale)
+            .setMessage(rationale)
             .setPositiveButton(model.positiveButtonText, this)
             .setNegativeButton(model.negativeButtonText, this)
             .show()
@@ -56,7 +57,7 @@ class RationaleDialog(
     fun showDialog() {
         android.app.AlertDialog.Builder(context, model.theme)
             .setCancelable(false)
-            .setMessage(model.rationale)
+            .setMessage(rationale)
             .setPositiveButton(model.positiveButtonText, this)
             .setNegativeButton(model.negativeButtonText, this)
             .show()

--- a/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/helpers/ActivityPermissionsHelper.kt
+++ b/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/helpers/ActivityPermissionsHelper.kt
@@ -18,6 +18,7 @@ package com.vmadalin.easypermissions.helpers
 import android.app.Activity
 import android.content.Context
 import androidx.core.app.ActivityCompat
+import com.vmadalin.easypermissions.EasyPermissions
 import com.vmadalin.easypermissions.dialogs.RationaleDialog
 import com.vmadalin.easypermissions.helpers.base.PermissionsHelper
 import com.vmadalin.easypermissions.models.PermissionRequest
@@ -40,6 +41,17 @@ internal class ActivityPermissionsHelper(
     }
 
     override fun showRequestPermissionRationale(permissionRequest: PermissionRequest) {
-        RationaleDialog(host, permissionRequest).showDialog()
+        when(permissionRequest.rationale) {
+            is EasyPermissions.RationaleType.StandardRationale -> {
+                RationaleDialog(
+                    host,
+                    permissionRequest,
+                    (permissionRequest.rationale as EasyPermissions.RationaleType.StandardRationale).rationale
+                ).showDialog()
+            }
+            is EasyPermissions.RationaleType.CustomRationale -> {
+                (permissionRequest.rationale as EasyPermissions.RationaleType.CustomRationale).rationale.invoke(permissionRequest)
+            }
+        }
     }
 }

--- a/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/helpers/AppCompatActivityPermissionsHelper.kt
+++ b/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/helpers/AppCompatActivityPermissionsHelper.kt
@@ -18,6 +18,7 @@ package com.vmadalin.easypermissions.helpers
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
+import com.vmadalin.easypermissions.EasyPermissions
 import com.vmadalin.easypermissions.dialogs.RationaleDialog
 import com.vmadalin.easypermissions.helpers.base.PermissionsHelper
 import com.vmadalin.easypermissions.models.PermissionRequest
@@ -40,6 +41,17 @@ internal class AppCompatActivityPermissionsHelper(
     }
 
     override fun showRequestPermissionRationale(permissionRequest: PermissionRequest) {
-        RationaleDialog(host, permissionRequest).showCompatDialog()
+        when(permissionRequest.rationale) {
+            is EasyPermissions.RationaleType.StandardRationale -> {
+                RationaleDialog(
+                    host,
+                    permissionRequest,
+                    (permissionRequest.rationale as EasyPermissions.RationaleType.StandardRationale).rationale
+                ).showCompatDialog()
+            }
+            is EasyPermissions.RationaleType.CustomRationale -> {
+                (permissionRequest.rationale as EasyPermissions.RationaleType.CustomRationale).rationale.invoke(permissionRequest)
+            }
+        }
     }
 }

--- a/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/helpers/FragmentPermissionsHelper.kt
+++ b/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/helpers/FragmentPermissionsHelper.kt
@@ -17,6 +17,7 @@ package com.vmadalin.easypermissions.helpers
 
 import android.content.Context
 import androidx.fragment.app.Fragment
+import com.vmadalin.easypermissions.EasyPermissions
 import com.vmadalin.easypermissions.dialogs.RationaleDialog
 import com.vmadalin.easypermissions.helpers.base.PermissionsHelper
 import com.vmadalin.easypermissions.models.PermissionRequest
@@ -40,7 +41,18 @@ internal class FragmentPermissionsHelper(
 
     override fun showRequestPermissionRationale(permissionRequest: PermissionRequest) {
         context?.let {
-            RationaleDialog(it, permissionRequest).showCompatDialog()
+            when(permissionRequest.rationale) {
+                is EasyPermissions.RationaleType.StandardRationale -> {
+                    RationaleDialog(
+                        it,
+                        permissionRequest,
+                        (permissionRequest.rationale as EasyPermissions.RationaleType.StandardRationale).rationale
+                    ).showCompatDialog()
+                }
+                is EasyPermissions.RationaleType.CustomRationale -> {
+                    (permissionRequest.rationale as EasyPermissions.RationaleType.CustomRationale).rationale.invoke(permissionRequest)
+                }
+            }
         }
     }
 }

--- a/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/models/PermissionRequest.kt
+++ b/easypermissions-ktx/src/main/java/com/vmadalin/easypermissions/models/PermissionRequest.kt
@@ -18,6 +18,7 @@ package com.vmadalin.easypermissions.models
 import android.content.Context
 import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
+import com.vmadalin.easypermissions.EasyPermissions
 import com.vmadalin.easypermissions.R
 
 /**
@@ -31,10 +32,17 @@ data class PermissionRequest(
     var theme: Int,
     var code: Int,
     var perms: Array<out String>,
-    var rationale: String?,
+    var rationale: EasyPermissions.RationaleType,
     var positiveButtonText: String?,
     var negativeButtonText: String?
 ) {
+
+    //Override invoke to pass model which contains code and perms as parameter
+    operator fun invoke (model: PermissionRequest) {
+        if(rationale is EasyPermissions.RationaleType.CustomRationale) {
+            (rationale as EasyPermissions.RationaleType.CustomRationale).rationale(model)
+        }
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -56,7 +64,7 @@ data class PermissionRequest(
         var result = theme
         result = 31 * result + code
         result = 31 * result + perms.contentHashCode()
-        result = 31 * result + (rationale?.hashCode() ?: 0)
+        result = 31 * result + rationale.hashCode()
         result = 31 * result + (positiveButtonText?.hashCode() ?: 0)
         result = 31 * result + (negativeButtonText?.hashCode() ?: 0)
         return result
@@ -73,15 +81,16 @@ data class PermissionRequest(
         private var theme = 0
         private var code = 0
         private var perms: Array<out String> = emptyArray()
-        private var rationale = context?.getString(R.string.rationale_ask)
+        //Changed rationale param by Unit to implement lambda functions on callback
+        private var rationale: EasyPermissions.RationaleType = EasyPermissions.RationaleType.StandardRationale(
+            context?.getString(R.string.rationale_ask) ?: "")
         private var positiveButtonText = context?.getString(android.R.string.ok)
         private var negativeButtonText = context?.getString(android.R.string.cancel)
 
         fun theme(@StyleRes theme: Int) = apply { this.theme = theme }
         fun code(code: Int) = apply { this.code = code }
         fun perms(perms: Array<out String>) = apply { this.perms = perms }
-        fun rationale(rationale: String) = apply { this.rationale = rationale }
-        fun rationale(@StringRes resId: Int) = apply { this.rationale = context?.getString(resId) }
+        fun rationale(rationale: EasyPermissions.RationaleType) = apply { this.rationale = rationale }
         fun positiveButtonText(positiveButtonText: String) =
             apply { this.positiveButtonText = positiveButtonText }
 

--- a/easypermissions-ktx/src/test/java/pub/devrel/easypermissions/EasyPermissionsLowApiTest.kt
+++ b/easypermissions-ktx/src/test/java/pub/devrel/easypermissions/EasyPermissionsLowApiTest.kt
@@ -17,23 +17,24 @@ package com.vmadalin.easypermissions
 
 import android.Manifest
 import androidx.test.core.app.ApplicationProvider
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.capture
 import com.vmadalin.easypermissions.components.TestActivity
 import com.vmadalin.easypermissions.components.TestAppCompatActivity
 import com.vmadalin.easypermissions.components.TestFragment
 import com.vmadalin.easypermissions.components.TestSupportFragmentActivity
 import com.vmadalin.easypermissions.controllers.ActivityController
 import com.vmadalin.easypermissions.controllers.FragmentController
-
-import com.google.common.truth.Truth.assertThat
-import org.mockito.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
-import com.nhaarman.mockitokotlin2.capture
+import org.mockito.Captor
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 private const val RATIONALE = "RATIONALE"
 private val ALL_PERMS = arrayOf(Manifest.permission.READ_SMS, Manifest.permission.ACCESS_FINE_LOCATION)
@@ -85,8 +86,8 @@ class EasyPermissionsLowApiTest {
     fun shouldCallbackOnPermissionGranted_whenRequestFromActivity() {
         EasyPermissions.requestPermissions(
             spyActivity,
-            RATIONALE,
             TestActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -99,8 +100,10 @@ class EasyPermissionsLowApiTest {
     fun shouldCallbackOnPermissionGranted_whenRequestFromSupportFragmentActivity() {
         EasyPermissions.requestPermissions(
             spySupportFragmentActivity,
-            RATIONALE,
             TestSupportFragmentActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale {
+
+            },
             *ALL_PERMS
         )
 
@@ -113,8 +116,8 @@ class EasyPermissionsLowApiTest {
     fun shouldCallbackOnPermissionGranted_whenRequestFromAppCompatActivity() {
         EasyPermissions.requestPermissions(
             spyAppCompatActivity,
-            RATIONALE,
             TestAppCompatActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -127,8 +130,10 @@ class EasyPermissionsLowApiTest {
     fun shouldCallbackOnPermissionGranted_whenRequestFromFragment() {
         EasyPermissions.requestPermissions(
             spyFragment,
-            RATIONALE,
             TestFragment.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale {
+
+            },
             *ALL_PERMS
         )
 

--- a/easypermissions-ktx/src/test/java/pub/devrel/easypermissions/EasyPermissionsTest.kt
+++ b/easypermissions-ktx/src/test/java/pub/devrel/easypermissions/EasyPermissionsTest.kt
@@ -41,6 +41,7 @@ import com.vmadalin.easypermissions.controllers.FragmentController
 import java.util.*
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.capture
+import com.vmadalin.easypermissions.dialogs.RationaleDialog
 import org.junit.Assert.fail
 import org.mockito.Mockito.*
 import org.robolectric.Shadows.shadowOf
@@ -158,8 +159,8 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyActivity,
-            RATIONALE,
             TestActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -179,8 +180,10 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyActivity,
-            RATIONALE,
             TestActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale {
+
+            },
             *ALL_PERMS
         )
 
@@ -194,8 +197,8 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyActivity,
-            RATIONALE,
             TestActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -209,8 +212,10 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyActivity,
-            RATIONALE,
             TestActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale {
+
+            },
             *ALL_PERMS
         )
 
@@ -224,8 +229,10 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyActivity,
-            RATIONALE,
             TestActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale { permissionRequest ->
+                RationaleDialog(spyActivity, permissionRequest, RATIONALE).showDialog()
+            },
             *ALL_PERMS
         )
 
@@ -242,7 +249,7 @@ class EasyPermissionsTest {
             .theme(R.style.Theme_AppCompat)
             .code(TestActivity.REQUEST_CODE)
             .perms(ALL_PERMS)
-            .rationale(android.R.string.unknownName)
+            .rationale(EasyPermissions.RationaleType.StandardRationale("Unknown"))
             .positiveButtonText(android.R.string.ok)
             .negativeButtonText(android.R.string.cancel)
             .build()
@@ -349,8 +356,10 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyAppCompatActivity,
-            RATIONALE,
             TestAppCompatActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale {
+
+            },
             *ALL_PERMS
         )
 
@@ -371,8 +380,8 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyAppCompatActivity,
-            RATIONALE,
             TestAppCompatActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -386,8 +395,10 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyAppCompatActivity,
-            RATIONALE,
             TestAppCompatActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale {
+
+            },
             *ALL_PERMS
         )
 
@@ -401,8 +412,8 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyAppCompatActivity,
-            RATIONALE,
             TestAppCompatActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -417,8 +428,10 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyAppCompatActivity,
-            RATIONALE,
             TestAppCompatActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale { permissionRequest ->
+                RationaleDialog(spyAppCompatActivity, permissionRequest, RATIONALE).showCompatDialog()
+            },
             *ALL_PERMS
         )
 
@@ -433,8 +446,8 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyFragmentActivity,
-            RATIONALE,
             TestSupportFragmentActivity.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -451,7 +464,9 @@ class EasyPermissionsTest {
             .theme(R.style.Theme_AppCompat)
             .code(TestAppCompatActivity.REQUEST_CODE)
             .perms(ALL_PERMS)
-            .rationale(android.R.string.unknownName)
+            .rationale(EasyPermissions.RationaleType.CustomRationale{ permissionRequest ->
+                RationaleDialog(spyFragmentActivity, permissionRequest, "Unknown").showCompatDialog()
+            })
             .positiveButtonText(android.R.string.ok)
             .negativeButtonText(android.R.string.cancel)
             .build()
@@ -568,8 +583,8 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyFragment,
-            RATIONALE,
             TestFragment.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -589,8 +604,10 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyFragment,
-            RATIONALE,
             TestFragment.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale {
+
+            },
             *ALL_PERMS
         )
 
@@ -604,8 +621,8 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyFragment,
-            RATIONALE,
             TestFragment.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -619,8 +636,10 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyFragment,
-            RATIONALE,
             TestFragment.REQUEST_CODE,
+            EasyPermissions.RationaleType.CustomRationale { permissionRequest ->
+                RationaleDialog(spyFragment.requireContext(), permissionRequest, RATIONALE).showDialog()
+            },
             *ALL_PERMS
         )
 
@@ -634,8 +653,8 @@ class EasyPermissionsTest {
 
         EasyPermissions.requestPermissions(
             spyFragment,
-            RATIONALE,
             TestFragment.REQUEST_CODE,
+            EasyPermissions.RationaleType.StandardRationale(RATIONALE),
             *ALL_PERMS
         )
 
@@ -652,7 +671,10 @@ class EasyPermissionsTest {
             .theme(R.style.Theme_AppCompat)
             .code(TestFragment.REQUEST_CODE)
             .perms(ALL_PERMS)
-            .rationale(RATIONALE)
+            .rationale(EasyPermissions.RationaleType.CustomRationale { permissionRequest ->
+                RationaleDialog(spyFragment.requireContext(), permissionRequest, RATIONALE).showDialog()
+
+            })
             .positiveButtonText(POSITIVE)
             .negativeButtonText(NEGATIVE)
             .build()

--- a/easypermissions-ktx/src/test/java/pub/devrel/easypermissions/RationaleDialogTest.kt
+++ b/easypermissions-ktx/src/test/java/pub/devrel/easypermissions/RationaleDialogTest.kt
@@ -31,6 +31,7 @@ import com.vmadalin.easypermissions.components.TestActivity
 import com.vmadalin.easypermissions.dialogs.RationaleDialog
 import com.vmadalin.easypermissions.models.PermissionRequest
 
+private const val RATIONALE = "RATIONALE"
 private const val REQUEST_CODE = 5
 private val PERMS = arrayOf(READ_SMS, ACCESS_FINE_LOCATION)
 
@@ -56,7 +57,7 @@ class RationaleDialogTest {
             .code(REQUEST_CODE)
             .perms(PERMS)
             .build()
-        rationaleDialog = RationaleDialog(testActivity, permissionRequest)
+        rationaleDialog = RationaleDialog(testActivity, permissionRequest, RATIONALE)
         rationaleDialog.onClick(dialogInterface, Dialog.BUTTON_POSITIVE)
 
         verify(testActivity).onRationaleAccepted(REQUEST_CODE)
@@ -68,7 +69,7 @@ class RationaleDialogTest {
     @Test
     fun shouldOnRationaleAcceptedWithDefaultValues_whenPositiveButtonClickedWithEmptyRequest() {
         val permissionRequest = PermissionRequest.Builder(testActivity).build()
-        rationaleDialog = RationaleDialog(testActivity, permissionRequest)
+        rationaleDialog = RationaleDialog(testActivity, permissionRequest, RATIONALE)
         rationaleDialog.onClick(dialogInterface, Dialog.BUTTON_POSITIVE)
 
         verify(testActivity).onRationaleAccepted(0)
@@ -83,7 +84,7 @@ class RationaleDialogTest {
             .code(REQUEST_CODE)
             .perms(PERMS)
             .build()
-        rationaleDialog = RationaleDialog(testActivity, permissionRequest)
+        rationaleDialog = RationaleDialog(testActivity, permissionRequest, RATIONALE)
         rationaleDialog.onClick(dialogInterface, Dialog.BUTTON_NEGATIVE)
 
         verify(testActivity).onRationaleDenied(REQUEST_CODE)
@@ -95,7 +96,7 @@ class RationaleDialogTest {
     @Test
     fun shouldOnRationaleDeclinedWithDefaultValues_whenPositiveButtonClickedWithEmptyRequest() {
         val permissionRequest = PermissionRequest.Builder(testActivity).build()
-        rationaleDialog = RationaleDialog(testActivity, permissionRequest)
+        rationaleDialog = RationaleDialog(testActivity, permissionRequest, RATIONALE)
         rationaleDialog.onClick(dialogInterface, Dialog.BUTTON_NEGATIVE)
 
         verify(testActivity).onRationaleDenied(0)
@@ -110,7 +111,7 @@ class RationaleDialogTest {
             .code(REQUEST_CODE)
             .perms(PERMS)
             .build()
-        rationaleDialog = RationaleDialog(testActivity, permissionRequest)
+        rationaleDialog = RationaleDialog(testActivity, permissionRequest, RATIONALE)
 
         verify(testActivity, never()).onRationaleAccepted(anyInt())
         verify(testActivity, never()).onRationaleDenied(anyInt())


### PR DESCRIPTION
**Summary**
Basically, this refactor allows to use  `Easy Permissions Rationale` (standard rationale) or create a custom rationale to be use in Easy Permissions flow, according with **Android Guidelines** to ask for Android Permissions.
**Standard Rationale**: It's a very basic `AlertDialog` which provides a message and ok/cancel buttons.
**Custom Rationale**: It's a `Lambda` function where you can place a custom dialog of your preference.

**Motivation**
This new flow was motivated by the lack of use custom rational dialogs with Easy Permission library. This library is so powerful and helps a lot since you don't need to handle ask for Android permission by your own, but it lacks of a way to use custom rational dialogs which are created in accordance with app UI guidelines. So, I propose a way that allows `Easy Permissions` users to decide which way take: Standard Rationale or Custom Rationale.




