### PR TITLE
Move test activities to test Manifest, in order not to pollute production Manifest

### DIFF
--- a/easypermissions-ktx/build.gradle
+++ b/easypermissions-ktx/build.gradle
@@ -11,7 +11,7 @@ ext {
     SNAPSHOT_REPOSITORY_URL = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 }
 
-apply plugin: 'com.vanniktech.maven.publish'
+//apply plugin: 'com.vanniktech.maven.publish'
 
 allOpen {
     annotation("com.vmadalin.easypermissions.annotations.Mockable")

--- a/easypermissions-ktx/src/main/AndroidManifest.xml
+++ b/easypermissions-ktx/src/main/AndroidManifest.xml
@@ -1,13 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--suppress AndroidDomInspection -->
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.vmadalin.easypermissions">
-
-    <application>
-        <activity android:name=".components.TestActivity"/>
-        <activity android:name=".components.TestAppCompatActivity"/>
-        <activity android:name=".components.TestSupportFragmentActivity"/>
-    </application>
-
-</manifest>
+<manifest package="com.vmadalin.easypermissions" />

--- a/easypermissions-ktx/src/test/AndroidManifest.xml
+++ b/easypermissions-ktx/src/test/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.vmadalin.easypermissions">
+
+    <application>
+        <activity android:name=".components.TestActivity"/>
+        <activity android:name=".components.TestAppCompatActivity"/>
+        <activity android:name=".components.TestSupportFragmentActivity"/>
+    </application>
+
+</manifest>


### PR DESCRIPTION
Fixes #13