### PR TITLE
append changelog to fulfill the license obligation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+*In compliance with the [APACHE-2.0](https://opensource.org/licenses/Apache-2.0) license: I declare that this version of the program contains my modifications, which can be seen through the usual "git" mechanism.*  
+
 Change Log
 ==========
 
@@ -10,3 +12,6 @@ Version 0.1.0 *(2020-12-22)*
 ----------------------------
 
  * First kotlin version of [EasyPermissions](https://github.com/googlesamples/easypermissions) android library.
+ * Api aligning with easypermissions (#2)  
+ * Fixed travis build failure  
+ * start migrate sample to kotlin  


### PR DESCRIPTION
### Reminding about missing "notices" for modifications on original work (violation of [APACHE-2.0](https://opensource.org/licenses/Apache-2.0))

Hello,

[**Modification terms and conditions in license**] The original work should be honored while the modifications on it should be attached with prominent notices as the license [APACHE-2.0](https://opensource.org/licenses/Apache-2.0) dictates. Your project is a forking project from [googlesamples/easypermissions](https://github.com/googlesamples/easypermissions) which adopts [APACHE-2.0](https://opensource.org/licenses/Apache-2.0) as its project license.  
The modification terms and conditions of [APACHE-2.0](https://opensource.org/licenses/Apache-2.0) dictate that:

>[APACHE-2.0](https://opensource.org/licenses/Apache-2.0):
>
>*... You must cause any modified files to carry prominent notices stating that You changed the files ...*

Therefore, we think the project is obligated to abide by the modification terms and conditions in [APACHE-2.0](https://opensource.org/licenses/Apache-2.0).

[**Violation of modification terms and conditions**] We run through your history, and it turns out that you have conducted modifications to the *source files* of original work while didn't provide prominent notices. 
You have **5** commits which conduct modifications to the files of original work, all of which are not declared in [README.md](https://github.com/vmadalin/easypermissions-ktx/blob/master/README.md), [CHANGELOG.md](https://github.com/vmadalin/easypermissions-ktx/blob/master/CHANGELOG.md). 
According to the license terms and conditions above, it is regarded as license violation. 
Thus, to avoid potential legal risks, I would suggest you carry out prominent notices for the **5** commits. 

[**Recommended Fix**] There are 2 recommended solutions to fulfill the modification related obligation of [APACHE-2.0](https://opensource.org/licenses/Apache-2.0):

1. *Git Mechanism*.
   + Just put a note in the top directory, something like MODIFICATION.md, or any file but the license text and NOTICES, in order to give people who follow you the most latitude to comply with the license without making a mess,
   + Write "In compliance with the [APACHE-2.0](https://opensource.org/licenses/Apache-2.0) license: I declare that this version of the program contains my modifications, which can be seen through the usual "git" mechanism."  
  
2. *Changelog Text*.  
   Or add changelog for modification to comply with the license.  
   
For your convenience, I created a PR with by picking up modification-related commit messages. It adds a few lines in [changelog](https://github.com/SilverSteven/easypermissions-ktx/blob/fulfill-license-obligation/CHANGELOG.md) without touching the codebase. Please be comfortable to check it out. 

Full details of the report you could refer to the [html](https://htmlpreview.github.io/?https://github.com/SilverSteven/easypermissions-ktx/blob/master/page.html) file attached. 
Hope it helps!

If there is anything wrong in this reminding, I'm sorry for my bothering, and please feel free to close this PR.

Cheers!





    